### PR TITLE
Release 1.3.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Changelog
 T4Utils 2 utilizes [GitHub's releases feature](https://github.com/blog/1547-release-your-software) for its changelogs, but this document serves as static duplicate of that content.
 
+## [v1.3.1_2016.10.13 - Global Context Variables](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.1_2016.10.13)
+Issues related to the `var context = content || null;` problem within page-layouts have been solved. Here's how:
+* In page-layouts, the original way of calculating context errors out. The following logic works and will be utilized: `var context = typeof content == 'undefined' ? null : content;`
+* All new `context`, `contextIsPage` and `contextIsContent` member variables have been added to the base `T4Utils` object
+    * This ensures that the context is defined globally at the start of the library
+    * The modules `brokerUtils`, `elementInfo` and `ordinalIndicators` now utilize these member variables in their logic
+
 ## [v1.3.0_2016.10.12 - Ordinal Indicators Failsafe](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.0_2016.10.12)
 A new failsafe has been added to `ordinalIndicators` to allow for the entire library to be used within page layouts. Here's what's changed:
 * All code within pageInfo/groupInfo has been wrapped in a conditional checking to see if the global variable `content` is undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t4-utils-2",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Javascript Library of Utility Classes and Extensions for TerminalFour Programmable Layouts",
   "main": "dist/8.4/T4Utils.min.js",
   "author": "Joel Eisner <eisnerjr@vcu.edu>",

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,12 @@ A Javascript library of utility classes and extensions for TerminalFour Programm
 
 ## Latest Version
 
-## [v1.3.0_2016.10.12 - Ordinal Indicators Failsafe](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.0_2016.10.12)
-A new failsafe has been added to `ordinalIndicators` to allow for the entire library to be used within page layouts. Here's what's changed:
-* All code within pageInfo/groupInfo has been wrapped in a conditional checking to see if the global variable `content` is undefined
-    * If `content` is defined, the self-executing functions will run as expected
-    * If `content` is undefined, the self-executing functions will return objects with null key/value pairs
+## [v1.3.1_2016.10.13 - Global Context Variables](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.1_2016.10.13)
+Issues related to the `var context = content || null;` problem within page-layouts have been solved. Here's how:
+* In page-layouts, the original way of calculating context errors out. The following logic works and will be utilized: `var context = typeof content == 'undefined' ? null : content;`
+* All new `context`, `contextIsPage` and `contextIsContent` member variables have been added to the base `T4Utils` object
+    * This ensures that the context is defined globally at the start of the library
+    * The modules `brokerUtils`, `elementInfo` and `ordinalIndicators` now utilize these member variables in their logic
 
 Check out the [changelog](changelog.md) for previous release information.
 

--- a/src/modules/base.js
+++ b/src/modules/base.js
@@ -2,7 +2,7 @@
  * T4Utils
  * @module
  * @author Ben Margevicius <bdm4@case.edu>, Joel Eisner <eisnerjr@vcu.edu>
- * @version 1.0.0
+ * @version 1.1.0
  */
 var T4Utils = (function (utils) {
 
@@ -76,6 +76,38 @@ var T4Utils = (function (utils) {
             document.write("<script>console.error('" + textOrObj + "');</script>\n");
         }
     };
+
+    /**
+     * Sets the context of where the library is being executed from (i.e. null if from within a page-layout, content if from within a content-type)
+     * @member context
+     * @return {?Object} context - Either null if the context is from within a page-layout, and the content variable if from withing a content-type
+     * T4Utils.context
+     */
+    utils.context = (function () {
+        return typeof content == 'undefined' ? null : content;
+    })();
+
+    /**
+     * Boolean of whether the context of where the library is being executed from is within a page-layout
+     * @member contextIsPage
+     * @return {boolean} context - True if the library is executed within a page-layout, false if not
+     * @example
+     * T4Utils.contextIsPage
+     */
+    utils.contextIsPage = (function () {
+        return typeof content == 'undefined' ? true : false;
+    })();
+
+    /**
+     * Boolean of whether the context of where the library is being executed from is within a content-type
+     * @member contextIsContent
+     * @return {boolean} context - True if the library is executed within a content-type, false if not
+     * @example
+     * T4Utils.contextIsContent
+     */
+    utils.contextIsContent = (function () {
+        return typeof content == 'undefined' ? false : true;
+    })();
 
     /**
      * Writes a paragraph formatted HTML message to the browser

--- a/src/modules/brokerUtils.js
+++ b/src/modules/brokerUtils.js
@@ -2,8 +2,8 @@
  * brokerUtils - The Broker Utilities Module
  * @namespace brokerUtils
  * @extends T4Utils
- * @author Ben Margevicius <bdm4@case.edu>
- * @version 1.0.0
+ * @author Ben Margevicius <bdm4@case.edu>, Joel Eisner <eisnerjr@vcu.edu>
+ * @version 1.1.0
  * @example
  * T4Utils.brokerUtils
  */
@@ -18,6 +18,5 @@ T4Utils.brokerUtils = T4Utils.brokerUtils || {};
  * T4Utils.brokerUtils.processT4tag(string);
  */
 T4Utils.brokerUtils.processT4Tag = function (t4Tag) {
-    var context = content || null;
-    return com.terminalfour.publish.utils.BrokerUtils.processT4Tags(dbStatement, publishCache, section, context, language, isPreview, t4Tag);
+    return com.terminalfour.publish.utils.BrokerUtils.processT4Tags(dbStatement, publishCache, section, T4Utils.context, language, isPreview, t4Tag);
 };

--- a/src/modules/elementInfo.js
+++ b/src/modules/elementInfo.js
@@ -2,8 +2,8 @@
  * elementInfo - The Element Info Module
  * @namespace elementInfo
  * @extends T4Utils
- * @author Ben Margevicius <bdm4@case.edu>
- * @version 1.0.0
+ * @author Ben Margevicius <bdm4@case.edu>, Joel Eisner <eisnerjr@vcu.edu>
+ * @version 1.1.0
  * @example
  * T4Utils.elementInfo
  */
@@ -17,8 +17,7 @@ T4Utils.elementInfo = T4Utils.elementInfo || {};
  * T4Utils.elementInfo.getElements();
  */
 T4Utils.elementInfo.getElements = function () {
-    var context = content || null;
-    return context !== null ? context.getElements() : null ;
+    return T4Utils.contextIsContent ? content.getElements() : null ;
 };
 
 /**
@@ -30,9 +29,8 @@ T4Utils.elementInfo.getElements = function () {
  * T4Utils.elementInfo.getElementValue(string);
  */
 T4Utils.elementInfo.getElementValue = function (element) {
-    var context = content || null;
-    if (context !== null) {
-        var el = context.get(element);
+    if (T4Utils.contextIsContent) {
+        var el = content.get(element);
         if (typeof el.publish === "function") {
             return el.publish();
         }
@@ -49,9 +47,8 @@ T4Utils.elementInfo.getElementValue = function (element) {
  * T4Utils.elementInfo.getElementName(string);
  */
 T4Utils.elementInfo.getElementName = function (element) {
-    var context = content || null;
-    if (context !== null) {
-        var el = context.get(element);
+    if (T4Utils.contextIsContent) {
+        var el = content.get(element);
         if (typeof el.getName === "function") {
             return c.get(element).getName();
         }
@@ -68,9 +65,8 @@ T4Utils.elementInfo.getElementName = function (element) {
  * T4Utils.elementInfo.getElementID(string);
  */
 T4Utils.elementInfo.getElementID = function (element) {
-    var context = content || null;
-    if (context !== null) {
-        var el = context.get(element);
+    if (T4Utils.contextIsContent) {
+        var el = content.get(element);
         if (typeof el.getID === "function") {
             return c.getID();
         }

--- a/src/modules/ordinalIndicators.js
+++ b/src/modules/ordinalIndicators.js
@@ -31,7 +31,7 @@ T4Utils.ordinalIndicators.pageInfo = (function() {
         return array;
     }
     // If content is defined...
-    if (typeof content !== 'undefined') {
+    if (T4Utils.contextIsContent) {
         // Grab all pieces of content on the page
         var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent(                            /* Extract all cached content from the page where... */
             com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent(                                 /* ... deleted content is ignored... */
@@ -152,7 +152,7 @@ T4Utils.ordinalIndicators.pageLast = T4Utils.ordinalIndicators.pageInfo.last;
  */
 T4Utils.ordinalIndicators.groupInfo = (function() {
     // If content is defined...
-    if (typeof content !== 'undefined') {
+    if (T4Utils.contextIsContent) {
         var ctid = content.getContentTypeID(),
             sid = section.getID(),
             oCH = new ContentHierarchy(),


### PR DESCRIPTION
* Added the context, contextIsPage, and contextIsContent members to base.js
* Anywhere context is needed (i.e. brokerUtils.js, elementInfo.js, and ordinalIndicators.js), implementation of the new context base members has been made
* Updated the package.json to version 1.3.1
* Updated the changelog.md and readme.md to include documentation for the 1.3.1 change