### PR TITLE
Release 1.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,15 @@
 # Changelog
 T4Utils 2 utilizes [GitHub's releases feature](https://github.com/blog/1547-release-your-software) for its changelogs, but this document serves as static duplicate of that content.
 
+## [v1.4.0_2016.10.31 - v7.4 Support](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.4.0_2016.10.31)
+T4Utils2 now officially supports both TerminalFour v7.4 and v8.1. Here's what's changed:
+* The Gulp build system now compiles 2 versions of the library (for TerminalFour v7.4 and v8.1)
+    * The main `gulpfile.js` now uses a build module to simplify and bootstrap library compilation code
+* The `ordinalIndicators` module now uses replaceable strings for any v7.1/v8.1 API discrepancies
+    * These replaceable strings are changed to the correct API calls during the build process
+* The `elementInfo` module has had undefined variable issues fixed
+* The `media` module's `getImageVariantsIds` method is now wrapped in a `T4Utils.contextIsContent` conditional
+
 ## [v1.3.1_2016.10.13 - Global Context Variables](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.1_2016.10.13)
 Issues related to the `var context = content || null;` problem within page-layouts have been solved. Here's how:
 * In page-layouts, the original way of calculating context errors out. The following logic works and will be utilized: `var context = typeof content == 'undefined' ? null : content;`

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -31,22 +31,22 @@ var api = {
 
 module.exports = function(gulp, config, version) {
     gulp.task('build-' + version, function() {
-        return gulp.src(config.src)                           // Grab the source files
-            .pipe(include())                                  // Include javascript modules
-            .pipe(replace(/\{\{version\}\}/g, pkg.version))   // Replace {{version}} with the package.json version
-            .pipe(replace(/\{\{t4_version\}\}/g, version))    // Replace {{t4_version}} with the passed in version
-            .pipe(replace(/\{\{datestamp\}\}/g, datestamp())) // Replace {{datestamp}} with a YYYY.mm.dd datestamp
-            .pipe(replace(/'\{\{api:content_type_id\}\}'/g, api.content_type_id[version]))
-            .pipe(replace(/'\{\{api:ocm\}\}'/g, api.ocm[version]))
-            .pipe(replace(/'\{\{api:ocm_get_id\}\}'/g, api.ocm_get_id[version]))
-            .pipe(replace(/'\{\{api:ocm_next_content_type_id\}\}'/g, api.ocm_next_content_type_id[version]))
-            .pipe(replace(/'\{\{api:ocm_prev_content_type_id\}\}'/g, api.ocm_prev_content_type_id[version]))
-            .pipe(header(version))                                   // Inject library header
-            .pipe(rename({suffix:'.' + version}))             // Give the filename a version suffix
-            .pipe(gulp.dest(config.dest))                     // Save to the destination folder
-            .pipe(uglify())                                   // Uglify the code
-            .pipe(header(version))                                   // Re-inject library header
-            .pipe(rename({suffix:'.min'}))                    // Give the filename a .min suffix
-            .pipe(gulp.dest(config.dest));                    // Save to the destination folder
+        return gulp.src(config.src)                                                                          // Grab the source files
+            .pipe(include())                                                                                 // Include javascript modules
+            .pipe(replace(/\{\{version\}\}/g, pkg.version))                                                  // Replace {{version}} with the package.json version
+            .pipe(replace(/\{\{t4_version\}\}/g, version))                                                   // Replace {{t4_version}} with the passed in version
+            .pipe(replace(/\{\{datestamp\}\}/g, datestamp()))                                                // Replace {{datestamp}} with a YYYY.mm.dd datestamp
+            .pipe(replace(/'\{\{api:content_type_id\}\}'/g, api.content_type_id[version]))                   // Replace {{api:content_type_id}} with the version specific JS
+            .pipe(replace(/'\{\{api:ocm\}\}'/g, api.ocm[version]))                                           // Replace {{api:ocm}} with the version specific JS
+            .pipe(replace(/'\{\{api:ocm_get_id\}\}'/g, api.ocm_get_id[version]))                             // Replace {{api:ocm_get_id}} with the version specific JS
+            .pipe(replace(/'\{\{api:ocm_next_content_type_id\}\}'/g, api.ocm_next_content_type_id[version])) // Replace {{api:ocm_next_content_type_id}} with the version specific JS
+            .pipe(replace(/'\{\{api:ocm_prev_content_type_id\}\}'/g, api.ocm_prev_content_type_id[version])) // Replace {{api:ocm_prev_content_type_id}} with the version specific JS
+            .pipe(header(version))                                                                           // Inject library header
+            .pipe(rename({suffix:'.' + version}))                                                            // Give the filename a version suffix
+            .pipe(gulp.dest(config.dest))                                                                    // Save to the destination folder
+            .pipe(uglify())                                                                                  // Uglify the code
+            .pipe(header(version))                                                                           // Re-inject library header
+            .pipe(rename({suffix:'.min'}))                                                                   // Give the filename a .min suffix
+            .pipe(gulp.dest(config.dest));                                                                   // Save to the destination folder
     });
 };

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -1,0 +1,52 @@
+var datestamp = require('./datestamp.js'),
+    header = require('./header.js'),
+    include = require('gulp-include'),
+    pkg = require('../package.json'),
+    rename = require('gulp-rename'),
+    replace = require('gulp-replace'),
+    uglify = require('gulp-uglify');
+
+var api = {
+    content_type_id: {
+        '8.1': 'content.getContentTypeID()',
+        '7.4': 'content.getTemplateID()'
+    },
+    ocm: {
+        '8.1': 'com.terminalfour.spring.ApplicationContextProvider.getBean(com.terminalfour.content.IContentManager)',
+        '7.4': 'ContentManager.getManager()'
+    },
+    ocm_get_id: {
+        '8.1': 'oCM.get(contentInSection[i], \'en\').getID()',
+        '7.4': 'oCM.get(dbStatement, contentInSection[i], \'en\').getID()'
+    },
+    ocm_next_content_type_id: {
+        '8.1': 'oCM.get(contentInSection[i + 1], \'en\').getContentTypeID()',
+        '7.4': 'oCM.get(dbStatement, contentInSection[i + 1], \'en\').getTemplateID()'
+    },
+    ocm_prev_content_type_id: {
+        '8.1': 'oCM.get(contentInSection[i - 1], \'en\').getContentTypeID()',
+        '7.4': 'oCM.get(dbStatement, contentInSection[i - 1], \'en\').getTemplateID()'
+    }
+};
+
+module.exports = function(gulp, config, version) {
+    gulp.task('build-' + version, function() {
+        return gulp.src(config.src)                           // Grab the source files
+            .pipe(include())                                  // Include javascript modules
+            .pipe(replace(/\{\{version\}\}/g, pkg.version))   // Replace {{version}} with the package.json version
+            .pipe(replace(/\{\{t4_version\}\}/g, version))    // Replace {{t4_version}} with the passed in version
+            .pipe(replace(/\{\{datestamp\}\}/g, datestamp())) // Replace {{datestamp}} with a YYYY.mm.dd datestamp
+            .pipe(replace(/'\{\{api:content_type_id\}\}'/g, api.content_type_id[version]))
+            .pipe(replace(/'\{\{api:ocm\}\}'/g, api.ocm[version]))
+            .pipe(replace(/'\{\{api:ocm_get_id\}\}'/g, api.ocm_get_id[version]))
+            .pipe(replace(/'\{\{api:ocm_next_content_type_id\}\}'/g, api.ocm_next_content_type_id[version]))
+            .pipe(replace(/'\{\{api:ocm_prev_content_type_id\}\}'/g, api.ocm_prev_content_type_id[version]))
+            .pipe(header(version))                                   // Inject library header
+            .pipe(rename({suffix:'.' + version}))             // Give the filename a version suffix
+            .pipe(gulp.dest(config.dest))                     // Save to the destination folder
+            .pipe(uglify())                                   // Uglify the code
+            .pipe(header(version))                                   // Re-inject library header
+            .pipe(rename({suffix:'.min'}))                    // Give the filename a .min suffix
+            .pipe(gulp.dest(config.dest));                    // Save to the destination folder
+    });
+};

--- a/gulp/header.js
+++ b/gulp/header.js
@@ -4,19 +4,20 @@ var datestamp = require('./datestamp.js'),
     pkg = require('../package.json');
 
 // Export
-module.exports = function() {
+module.exports = function(version) {
     // Define banner structure
     var banner = [
         '/**',
         ' * T4Utils 2',
         ' * @author <%= pkg.author %>',
-        ' * @version <%= pkg.version %>_<%= info.date %>',
+        ' * @version <%= pkg.version %>_<%= info.version %>_<%= info.date %>',
         ' * @license <%= pkg.license %>',
         ' */',
         '\n'
     ].join('\n');
     // Define the build information
     var info = {
+        version: version,
         date: datestamp()
     };
     // Return

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,46 +1,20 @@
 // Required Modules
-var config = require('./gulp/config.js'),
-    datestamp = require('./gulp/datestamp.js'),
+var build = require('./gulp/build.js'),
+    config = require('./gulp/config.js'),
     gulp = require('gulp'),
-    header = require('./gulp/header.js'),
-    include = require('gulp-include'),
-    jsdoc = require('gulp-jsdoc3'),
-    pkg = require('./package.json'),
-    rename = require('gulp-rename'),
-    replace = require('gulp-replace'),
-    uglify = require('gulp-uglify');
+    jsdoc = require('gulp-jsdoc3');
 
 // Default Task
 gulp.task('default', ['build']);
 
 // Build Task
-gulp.task('build', ['build-exp', 'build-min']);
-
-// Build Expanded Task
-gulp.task('build-exp', function() {
-    return gulp.src(config.src)                           /* Grab the source files */
-        .pipe(include())                                  /* Include javascript modules */
-        .pipe(replace(/\{\{version\}\}/g, pkg.version))   /* Replace {{version}} with the package.json version */
-        .pipe(replace(/\{\{datestamp\}\}/g, datestamp())) /* Replace {{datestamp}} with a YYYY.mm.dd datestamp */
-        .pipe(header())                                   /* Inject library header */
-        .pipe(gulp.dest(config.dest));                    /* Save to the destination folder  */
-});
-
-// Build Minified Task
-gulp.task('build-min', function() {
-    return gulp.src(config.src)                           /* Grab the source files */
-        .pipe(include())                                  /* Include javascript modules */
-        .pipe(replace(/\{\{version\}\}/g, pkg.version))   /* Replace {{version}} with the package.json version */
-        .pipe(replace(/\{\{datestamp\}\}/g, datestamp())) /* Replace {{datestamp}} with a YYYY.mm.dd datestamp */
-        .pipe(uglify())                                   /* Uglify the code */
-        .pipe(header())                                   /* Inject library header */
-        .pipe(rename({suffix:'.min'}))                    /* Give the filename a .min suffix */
-        .pipe(gulp.dest(config.dest));                    /* Save to the destination folder  */
-});
+gulp.task('build', ['build-8.1', 'build-7.4']); // Build both versions of the library
+build(gulp, config, '8.1');                     // Build the v8 version of the library
+build(gulp, config, '7.4');                     // Build the v7 version of the library
 
 // Watch Task
 gulp.task('watch', function() {
-    gulp.watch(config.watch, ['build']);                  /* Run the build task */
+    gulp.watch(config.watch, ['build']);        // Run the build task
 });
 
 // Docs Task

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t4-utils-2",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A Javascript Library of Utility Classes and Extensions for TerminalFour Programmable Layouts",
   "main": "dist/8.4/T4Utils.min.js",
   "author": "Joel Eisner <eisnerjr@vcu.edu>",

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,14 @@ A Javascript library of utility classes and extensions for TerminalFour Programm
 
 ## Latest Version
 
-## [v1.3.1_2016.10.13 - Global Context Variables](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.3.1_2016.10.13)
-Issues related to the `var context = content || null;` problem within page-layouts have been solved. Here's how:
-* In page-layouts, the original way of calculating context errors out. The following logic works and will be utilized: `var context = typeof content == 'undefined' ? null : content;`
-* All new `context`, `contextIsPage` and `contextIsContent` member variables have been added to the base `T4Utils` object
-    * This ensures that the context is defined globally at the start of the library
-    * The modules `brokerUtils`, `elementInfo` and `ordinalIndicators` now utilize these member variables in their logic
+## [v1.4.0_2016.10.31 - v7.4 Support](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.4.0_2016.10.31)
+T4Utils2 now officially supports both TerminalFour v7.4 and v8.1. Here's what's changed:
+* The Gulp build system now compiles 2 versions of the library (for TerminalFour v7.4 and v8.1)
+    * The main `gulpfile.js` now uses a build module to simplify and bootstrap library compilation code
+* The `ordinalIndicators` module now uses replaceable strings for any v7.1/v8.1 API discrepancies
+    * These replaceable strings are changed to the correct API calls during the build process
+* The `elementInfo` module has had undefined variable issues fixed
+* The `media` module's `getImageVariantsIds` method is now wrapped in a `T4Utils.contextIsContent` conditional
 
 Check out the [changelog](changelog.md) for previous release information.
 

--- a/src/modules/base.js
+++ b/src/modules/base.js
@@ -2,7 +2,7 @@
  * T4Utils
  * @module
  * @author Ben Margevicius <bdm4@case.edu>, Joel Eisner <eisnerjr@vcu.edu>
- * @version 1.1.0
+ * @version 1.2.0
  */
 var T4Utils = (function (utils) {
 
@@ -13,7 +13,7 @@ var T4Utils = (function (utils) {
      * @example
      * T4Utils.version;
      */
-    utils.version = '{{version}}_{{datestamp}}';
+    utils.version = '{{version}}_{{t4_version}}_{{datestamp}}';
 
     /**
      * The version of TerminalFour this library is intended for
@@ -22,7 +22,7 @@ var T4Utils = (function (utils) {
      * @example
      * T4Utils.t4;
      */
-    utils.t4 = '8.1';
+    utils.t4 = '{{t4_version}}';
 
     /**
      * Writes the specified message type to the browser console

--- a/src/modules/elementInfo.js
+++ b/src/modules/elementInfo.js
@@ -50,7 +50,7 @@ T4Utils.elementInfo.getElementName = function (element) {
     if (T4Utils.contextIsContent) {
         var el = content.get(element);
         if (typeof el.getName === "function") {
-            return c.get(element).getName();
+            return el.getName();
         }
     }
     return null;
@@ -68,7 +68,7 @@ T4Utils.elementInfo.getElementID = function (element) {
     if (T4Utils.contextIsContent) {
         var el = content.get(element);
         if (typeof el.getID === "function") {
-            return c.getID();
+            return el.getID();
         }
     }
     return null;

--- a/src/modules/media.js
+++ b/src/modules/media.js
@@ -18,9 +18,12 @@ T4Utils.media = T4Utils.media || {};
  * T4Utils.media.getImageVariantsIds(media);
  */
 T4Utils.media.getImageVariantsIds = function (mediaElement) {
-    var imageID = content.get(mediaElement).getID(),
-        variantIds = MediaManager.getManager().getMediaVariants(dbStatement.getConnection(), imageID, language);
-    return variantIds;
+    if (T4Utils.contextIsContent) {
+        var imageID = content.get(mediaElement).getID(),
+            variantIds = MediaManager.getManager().getMediaVariants(dbStatement.getConnection(), imageID, language);
+        return variantIds;
+    }
+    return null;
 };
 
 /**

--- a/src/modules/ordinalIndicators.js
+++ b/src/modules/ordinalIndicators.js
@@ -3,7 +3,7 @@
  * @namespace ordinalIndicators
  * @extends T4Utils
  * @author Joel Eisner <eisnerjr@vcu.edu>
- * @version 1.1.0
+ * @version 1.2.0
  * @example
  * T4Utils.ordinalIndicators
  */
@@ -61,9 +61,9 @@ T4Utils.ordinalIndicators.pageInfo = (function() {
                 if (ctID === contentTypeID.key) contentTypeID.pieces.push(uID);
             }
         }
-        // Get the current content's...
-        var this_ctID = content.getContentTypeID(), /* Content-type ID */
-            this_uID = content.getID();             /* Unique ID */
+        // Get the current content's content-type and unique ID's
+        var this_ctID = '{{api:content_type_id}}',
+            this_uID = content.getID();
         // For each key/pieces object...
         for (var m = 0; m < listContentTypeIDs.length; m++) {
             // ... create a reference, ...
@@ -153,16 +153,16 @@ T4Utils.ordinalIndicators.pageLast = T4Utils.ordinalIndicators.pageInfo.last;
 T4Utils.ordinalIndicators.groupInfo = (function() {
     // If content is defined...
     if (T4Utils.contextIsContent) {
-        var ctid = content.getContentTypeID(),
+        var ctid = '{{api:content_type_id}}',
             sid = section.getID(),
             oCH = new ContentHierarchy(),
-            oCM = com.terminalfour.spring.ApplicationContextProvider.getBean(com.terminalfour.content.IContentManager),
+            oCM = '{{api:ocm}}',
             contentInSection = oCH.getContent(dbStatement, sid, 'en'),
             groupFirst, groupLast;
         for (var i = 0; i < contentInSection.length; i++) {
-            if (content.getID() === oCM.get(contentInSection[i], 'en').getID()) {
-                groupFirst = i === 0 ? true : ctid !== oCM.get(contentInSection[i - 1], 'en').getContentTypeID() ? true : false;
-                groupLast = i === contentInSection.length - 1 ? true : ctid !== oCM.get(contentInSection[i + 1], 'en').getContentTypeID() ? true : false;
+            if (content.getID() === '{{api:ocm_get_id}}') {
+                groupFirst = i === 0 ? true : ctid !== '{{api:ocm_prev_content_type_id}}' ? true : false;
+                groupLast = i === contentInSection.length - 1 ? true : ctid !== '{{api:ocm_next_content_type_id}}' ? true : false;
             }
         }
         // Return an object that contains...


### PR DESCRIPTION
* Updated the elementInfo module to fix undefined variable names
* Updated the media module to encapsulate the "getImageVariantsIds" in a contextIsContent conditional
* Combined exp/min build tasks in gulpfile.js into an executable module called gulp/build.js which now compiles the sourcecode into 7.4 and 8.1 versions
* Updated the base module to include a replaceable t4_version strings
* Updated the ordinalIndicators module to include replaceable strings for every v8/v7 API discrepency
* The gulp/header module is now allowing a t4 version to be passed in
* Updated the readme.md and changelog.md to include documentation on the 1.4.0 changes
* Updated the package.json to version ✨ 1.4.0 ✨
* Updated the gulp/build module to provide better comment documentation and indentation