### PR TITLE
Bugfix 1.5.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 T4Utils 2 utilizes [GitHub's releases feature](https://github.com/blog/1547-release-your-software) for its changelogs, but this document serves as static duplicate of that content.
 
+### [v1.5.1_2016.12.19 - generateT4Tag() v7 Bug Fix](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.5.1_2016.12.19)
+This is a v7 bug fix for `brokerUtils`'s module `generateT4Tag()`. Here's the scoop:
+* T4 was processing the tag templates before being loaded into a content type or page layout.
+    * No matter how this module was used, an empty string was always returned
+* The first `<` of the tag template has been replaced with the unicode equivalent `\u003C`
+
 ## [v1.5.0_2016.12.09 - generateT4Tag()](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.5.0_2016.12.09)
 The `brokerUtils` module has been extended to include `generateT4Tag()`!
 * Create/process T4 tags by passing in a configuration object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t4-utils-2",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A Javascript Library of Utility Classes and Extensions for TerminalFour Programmable Layouts",
   "main": "dist/8.4/T4Utils.min.js",
   "author": "Joel Eisner <eisnerjr@vcu.edu>",

--- a/readme.md
+++ b/readme.md
@@ -5,27 +5,11 @@ A Javascript library of utility classes and extensions for TerminalFour Programm
 
 ## Latest Version
 
-### [v1.5.0_2016.12.09 - generateT4Tag()](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.5.0_2016.12.09)
-The `brokerUtils` module has been extended to include `generateT4Tag()`!
-* Create/process T4 tags by passing in a configuration object
-    * *type* (content, media, navigation, title)
-        * type - string
-        * default - "content"
-    * *name*
-        * type - string
-        * default - ""
-    * *output*
-        * type - string
-        * default - "normal"
-    * *modifiers*
-        * type - array
-        * default - []
-    * *id*
-        * type - number
-        * default - 0
-    * *formatter*
-        * type - string
-        * default - ""
+### [v1.5.1_2016.12.19 - generateT4Tag() v7 Bug Fix](https://github.com/virginiacommonwealthuniversity/T4Utils2/releases/tag/v1.5.1_2016.12.19)
+This is a v7 bug fix for `brokerUtils`'s module `generateT4Tag()`. Here's the scoop:
+* T4 was processing the tag templates before being loaded into a content type or page layout.
+    * No matter how this module was used, an empty string was always returned
+* The first `<` of the tag template has been replaced with the unicode equivalent `\u003C`
 
 Check out the [changelog](changelog.md) for previous release information.
 

--- a/src/modules/brokerUtils.js
+++ b/src/modules/brokerUtils.js
@@ -40,13 +40,13 @@ T4Utils.brokerUtils.generateT4Tag = function(userConfig) {
         },
         tag = '';
     // Type: Content; Required: Name
-    if (settings.type == 'content' && settings.name) tag += '<t4 type="' + settings.type + '" name="' + settings.name + '" output="' + settings.output + '" modifiers="' + settings.modifiers.join(',') + '"' + (settings.formatter ? ' formatter="' + settings.formatter + '"' : '') + ' />';
+    if (settings.type == 'content' && settings.name) tag += '\u003Ct4 type="' + settings.type + '" name="' + settings.name + '" output="' + settings.output + '" modifiers="' + settings.modifiers.join(',') + '"' + (settings.formatter ? ' formatter="' + settings.formatter + '"' : '') + ' />';
     // Type: Media; Required: Formatter, ID
-    if (settings.type == 'media' && settings.formatter && settings.id) tag += '<t4 type="' + settings.type + '" id="' + settings.id + '" formatter="' + settings.formatter + '" />';
+    if (settings.type == 'media' && settings.formatter && settings.id) tag += '\u003Ct4 type="' + settings.type + '" id="' + settings.id + '" formatter="' + settings.formatter + '" />';
     // Type: Navigation; Required: ID
-    if (settings.type == 'navigation' && settings.id) tag += '<t4 type="' + settings.type + '" id="' + settings.id + '" />';
+    if (settings.type == 'navigation' && settings.id) tag += '\u003Ct4 type="' + settings.type + '" id="' + settings.id + '" />';
     // Type: Title
-    if (settings.type == 'title') tag += '<t4 type="' + settings.type + '" />';
+    if (settings.type == 'title') tag += '\u003Ct4 type="' + settings.type + '" />';
     // If a tag was generated, return its computed value; Otherwise, return an empty string
     return tag ? T4Utils.brokerUtils.processT4Tag(tag) : '';
 };


### PR DESCRIPTION
* Updated the generateT4Tag module of brokerUtils; now escaping the first "<" in its output with a unicode equivalent ("\u003C")
* Updated the changelog and readme to include documentation for the 1.5.1 bug fix
* Updated the package.json to version 1.5.1 🐞